### PR TITLE
[EPIC-3694] License toast fixes

### DIFF
--- a/ScanbotSDKExamples/MAUI/ClassicComponent.Maui/Handlers/BarcodeCameraViewHandler.Android.cs
+++ b/ScanbotSDKExamples/MAUI/ClassicComponent.Maui/Handlers/BarcodeCameraViewHandler.Android.cs
@@ -24,6 +24,7 @@ namespace ClassicComponent.Maui.CustomViews
         // Classical component
         protected BarcodeScannerView cameraViewDroid;
         private readonly int REQUEST_PERMISSION_CODE = 200;
+        private bool toastShown = false;
 
         #region Handler Overrides
 
@@ -155,9 +156,14 @@ namespace ClassicComponent.Maui.CustomViews
 
         private bool HandleFrameHandlerResult(BarcodeScanningResult result, IO.Scanbot.Sdk.SdkLicenseError error)
         {
-            if (result == null)
+            if (result == null && !DocumentSDK.MAUI.ScanbotSDK.SDKService.IsLicenseValid)
             {
-                cameraViewDroid.Post(() => Toast.MakeText(Context.GetActivity(), "License has expired!", ToastLength.Long).Show());
+                if (!toastShown)
+                {
+                    cameraViewDroid.Post(() => Toast.MakeText(Context.GetActivity(), "License has expired!", ToastLength.Long).Show());
+                    toastShown = true;
+                }
+                
                 return false;
             }
 

--- a/ScanbotSDKExamples/MAUI/ClassicComponent.Maui/MainPage.xaml.cs
+++ b/ScanbotSDKExamples/MAUI/ClassicComponent.Maui/MainPage.xaml.cs
@@ -107,6 +107,7 @@ namespace ClassicComponent.Maui
 
             if (!IsLicenseValid)
             {
+                IsDetectionOn = false;
                 ShowExpiredLicenseAlert();
                 return;
             }

--- a/ScanbotSDKExamples/MAUI/ClassicComponent.Maui/Platforms/iOS/CustomViews/BarcodeCameraView_iOS.cs
+++ b/ScanbotSDKExamples/MAUI/ClassicComponent.Maui/Platforms/iOS/CustomViews/BarcodeCameraView_iOS.cs
@@ -115,6 +115,8 @@ namespace ClassicComponent.Maui.Platforms.iOS.CustomViews
         public delegate void OnDetectHandler(SBSDKBarcodeScannerResult[] codes);
         public OnDetectHandler OnDetect;
 
+        private bool alertShown = false;
+
         public override void DidDetectBarcodes(SBSDKBarcodeScannerViewController controller, SBSDKBarcodeScannerResult[] codes)
         {
             OnDetect?.Invoke(codes);
@@ -128,7 +130,12 @@ namespace ClassicComponent.Maui.Platforms.iOS.CustomViews
             }
             else
             {
-                ViewUtils.ShowAlert("License Expired!", "Ok");
+                if (!alertShown)
+                {
+                    ViewUtils.ShowAlert("License Expired!", "Ok");
+                    alertShown = true;
+                }
+                
                 return false;
             }
         }


### PR DESCRIPTION
The license toast can often show up even though scanning is taking place.

Now, it only shows when there is an error and only shows once (because it's usually only going to appear if the temporary license is going to expire). 

Another minor change is that pressing **Stop Scanning** button will stop scanning (before it would just keep showing the toast without stopping). 