### PR TITLE
Net 8.0 support for example projects.

### DIFF
--- a/ScanbotSDKExamples/MAUI/ClassicComponent.Maui/ClassicComponent.Maui.csproj
+++ b/ScanbotSDKExamples/MAUI/ClassicComponent.Maui/ClassicComponent.Maui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
-        <TargetFrameworks>net7.0-android;net7.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <UseMaui>true</UseMaui>
         <SingleProject>true</SingleProject>
@@ -21,11 +21,11 @@
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">13.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0-ios|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
         <CreatePackage>false</CreatePackage>
-        <MtouchLink>SdkOnly</MtouchLink>
+        <MtouchLink>None</MtouchLink>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net7.0-ios|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
       <CreatePackage>false</CreatePackage>
     </PropertyGroup>
     <ItemGroup>
@@ -45,16 +45,16 @@
         <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
         <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
     </ItemGroup>
-    <ItemGroup Condition="$(TargetFramework.StartsWith('net7.0-android')) != true">
+    <ItemGroup Condition="$(TargetFramework.StartsWith('net8.0-android')) != true">
         <Compile Remove="**\**\*.Android.cs" />
         <None Include="**\**\*.Android.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     </ItemGroup>
-        <ItemGroup Condition="$(TargetFramework.StartsWith('net7.0-ios')) != true">
+        <ItemGroup Condition="$(TargetFramework.StartsWith('net8.0-ios')) != true">
         <Compile Remove="**\**\*.iOS.cs" />
         <None Include="**\**\*.iOS.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="ScanbotSDK.MAUI" Version="2.3.1-beta.2" />
+      <PackageReference Include="ScanbotSDK.MAUI" Version="2.3.1" />
     </ItemGroup>
     <ItemGroup>
       <Folder Include="Platforms\Android\Resources\" />

--- a/ScanbotSDKExamples/MAUI/ReadyToUseUI.Maui/ReadyToUseUI.Maui.csproj
+++ b/ScanbotSDKExamples/MAUI/ReadyToUseUI.Maui/ReadyToUseUI.Maui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <!-- ===================== Common Project Configs/Architecture =====================  -->
     <PropertyGroup>
-        <TargetFrameworks>net7.0-ios;net7.0-android</TargetFrameworks>
+        <TargetFrameworks>net8.0-ios;net8.0-android</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <UseMaui>true</UseMaui>
         <SingleProject>true</SingleProject>
@@ -17,19 +17,22 @@
         <ApplicationVersion>1.0</ApplicationVersion>
         <!-- Supported Platforms -->
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">13.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21</SupportedOSPlatformVersion>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='net7.0-ios|ARM64'">
+    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='net8.0-ios|ARM64'">
         <MtouchLink>SdkOnly</MtouchLink>
         <MtouchInterpreter>-all</MtouchInterpreter>
         <CreatePackage>false</CreatePackage>
         <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'!='net7.0-ios|ARM64'">
+    <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'!='net8.0-ios|ARM64'">
         <MtouchLink>SdkOnly</MtouchLink>
         <CreatePackage>false</CreatePackage>
     </PropertyGroup>
     <!-- ===================== Application Resources =====================  -->
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
+      <MtouchLink>None</MtouchLink>
+    </PropertyGroup>
     <ItemGroup>
         <!-- App Icon -->
         <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
@@ -44,7 +47,7 @@
         <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
     </ItemGroup>
     <!-- ===================== IOS Project References =====================  -->
-    <ItemGroup Condition="'$(TargetFramework)|$(Platform)'=='net7.0-ios|AnyCPU'">
+    <ItemGroup Condition="'$(TargetFramework)|$(Platform)'=='net8.0-ios|AnyCPU'">
         <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -57,11 +60,11 @@
         <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
         <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.4" />
         <PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
-        <PackageReference Include="ScanbotSDK.MAUI" Version="2.3.1-beta.2" />
+        <PackageReference Include="ScanbotSDK.MAUI" Version="2.3.1" />
     </ItemGroup>
     
     <!-- ===================== IOS OCR Data Files =====================  -->
-    <ItemGroup Condition="'$(TargetFramework)|$(Platform)'=='net7.0-ios|AnyCPU'">
+    <ItemGroup Condition="'$(TargetFramework)|$(Platform)'=='net8.0-ios|AnyCPU'">
         <BundleResource Include="Resources\ScanbotSDKOCRData.bundle\eng.traineddata" />
         <BundleResource Include="Resources\ScanbotSDKOCRData.bundle\deu.traineddata" />
         <BundleResource Include="Resources\ScanbotSDKOCRData.bundle\osd.traineddata" />

--- a/ScanbotSDKExamples/NET/ClassicComponent.Droid/ClassicComponent.Droid.csproj
+++ b/ScanbotSDKExamples/NET/ClassicComponent.Droid/ClassicComponent.Droid.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0-android</TargetFramework>
+        <TargetFramework>net8.0-android</TargetFramework>
         <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
         <OutputType>Exe</OutputType>
         <Nullable>disable</Nullable>
@@ -12,12 +12,15 @@
         <ApplicationTitle>NET Classic Component</ApplicationTitle>
       <RootNamespace>ClassicComponent.Droid</RootNamespace>
   </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+      <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+    </PropertyGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\SBSDKLanguageData\deu.traineddata" />
     <AndroidAsset Include="Assets\SBSDKLanguageData\eng.traineddata" />
     <AndroidAsset Include="Assets\SBSDKLanguageData\osd.traineddata" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ScanbotSDK.NET" Version="2.3.1-beta.2" />
+    <PackageReference Include="ScanbotSDK.NET" Version="2.3.1" />
   </ItemGroup>
 </Project>

--- a/ScanbotSDKExamples/NET/ClassicComponent.iOS/ClassicComponent.iOS.csproj
+++ b/ScanbotSDKExamples/NET/ClassicComponent.iOS/ClassicComponent.iOS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0-ios</TargetFramework>
+        <TargetFramework>net8.0-ios</TargetFramework>
         <OutputType>Exe</OutputType>
         <Nullable>disable</Nullable>
         <ImplicitUsings>true</ImplicitUsings>
@@ -13,12 +13,12 @@
         <CreatePackage>false</CreatePackage>
         <CodesignProvision>Automatic</CodesignProvision>
         <CodesignKey>iPhone Developer</CodesignKey>
-        <MtouchLink>SdkOnly</MtouchLink>
+        <MtouchLink>None</MtouchLink>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <CreatePackage>false</CreatePackage>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="ScanbotSDK.NET" Version="2.3.1-beta.2" />
+        <PackageReference Include="ScanbotSDK.NET" Version="2.3.1" />
     </ItemGroup>
 </Project>

--- a/ScanbotSDKExamples/NET/ReadyToUseUI.Droid/ReadyToUseUI.Droid.csproj
+++ b/ScanbotSDKExamples/NET/ReadyToUseUI.Droid/ReadyToUseUI.Droid.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0-android</TargetFramework>
+        <TargetFramework>net8.0-android</TargetFramework>
         <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
         <OutputType>Exe</OutputType>
         <Nullable>disable</Nullable>
@@ -11,7 +11,10 @@
         <AssemblyName>ReadyToUseUI.Droid</AssemblyName>
         <ApplicationTitle>NET RTU UI</ApplicationTitle>
     </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+      <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+    </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="ScanbotSDK.NET" Version="2.3.1-beta.2" />
+        <PackageReference Include="ScanbotSDK.NET" Version="2.3.1" />
     </ItemGroup>
 </Project>

--- a/ScanbotSDKExamples/NET/ReadyToUseUI.iOS/ReadyToUseUI.iOS.csproj
+++ b/ScanbotSDKExamples/NET/ReadyToUseUI.iOS/ReadyToUseUI.iOS.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net7.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0-ios</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <ImplicitUsings>enable</ImplicitUsings>
         
@@ -15,14 +15,17 @@
         <ApplicationVersion>1</ApplicationVersion>
         
         <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
-        <MtouchLink>SdkOnly</MtouchLink>
+        <MtouchLink>None</MtouchLink>
         <CreatePackage>false</CreatePackage>
         <CodesignProvision>Automatic</CodesignProvision>
         <CodesignKey>iPhone Developer</CodesignKey>
         <MtouchDebug>true</MtouchDebug>
     </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+      <MtouchLink>None</MtouchLink>
+    </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="ScanbotSDK.NET" Version="2.3.1-beta.2" />
+        <PackageReference Include="ScanbotSDK.NET" Version="2.3.1" />
     </ItemGroup>
     <ItemGroup>
         <BundleResource Include="Resources\ScanbotSDKOCRData.bundle\eng.traineddata" />


### PR DESCRIPTION
- [x] Updated the net sdk version from net7.0 to to net8.0. Tested the projects, working fine.

**Steps involved for updating:**

1. Update Visual Studio for Mac to the latest update(version 17.6.7).
2. Download from here the latest [net8.0 SDK]( https://dotnet.microsoft.com/en-us/download/dotnet/8.0), for the requited platform Mac/Windows. I downloaded [Mac arm64](https://download.visualstudio.microsoft.com/download/pr/cf196f2f-f1e2-4f9a-a7ac-546242c431e2/8c386932f4a2f96c3e95c433e4899ec2/dotnet-sdk-8.0.100-osx-arm64.pkg). Then Install it.
3. Now, In example project update all the .csproj files from net7.0 to net8.0. Restart VS, you cannot be lucky here. 
4. Now, there will be a warning to install NET Workloads, if you click on install it may fail. 
5. If it fails: run` sudo dotnet workload restore`. After installation completes,  you can Try rebuilding and running project.

In case of any blocker. Restart VS is the first Step.