### PR TITLE
[EPIC-4875] NET DS - Infinite Loading - Related to Parametric Filters

### DIFF
--- a/NET/ReadyToUseUI.Droid/Activities/PageFilterActivity.cs
+++ b/NET/ReadyToUseUI.Droid/Activities/PageFilterActivity.cs
@@ -127,11 +127,11 @@ namespace ReadyToUseUI.Droid.Activities
 
             Task.Run(delegate
             {
-                var uri = pageStorage.GetFilteredPreviewImageURI(selectedPageId, null); // None
+                var uri = pageStorage.GetFilteredPreviewImageURI(selectedPageId, new LegacyFilter(ImageFilterType.None.Code)); 
 
                 if (!File.Exists(uri.Path))
                 {
-                    pageProcessor.GenerateFilteredPreview(new Page().Copy(pageId: selectedPageId), null);
+                    pageProcessor.GenerateFilteredPreview(new Page().Copy(pageId: selectedPageId),  new LegacyFilter(ImageFilterType.None.Code));
                 }
 
                 UpdateImage(uri);

--- a/NET/ReadyToUseUI.Droid/Activities/V2/BarcodeResultActivity.cs
+++ b/NET/ReadyToUseUI.Droid/Activities/V2/BarcodeResultActivity.cs
@@ -63,6 +63,9 @@ namespace ReadyToUseUI.Droid.Activities.V2
         
         private string ParseData(IO.Scanbot.Genericdocument.Entity.GenericDocument result)
         {
+            if (result == null)
+                return string.Empty;
+            
             var builder = new StringBuilder();
             var description = string.Join(";\n", result.Fields?
                 .Where(field => field != null)

--- a/NET/ReadyToUseUI.Droid/MainActivity.DataDetector.cs
+++ b/NET/ReadyToUseUI.Droid/MainActivity.DataDetector.cs
@@ -48,12 +48,12 @@ public partial class MainActivity
         configuration.SetCancelButtonTitle("Done");
 
         // Specify accepted types if needed
-        configuration.SetAcceptedDocumentTypes(new List<RootDocumentType>
-        {
-            RootDocumentType.DeIdCardFront,
-            //RootDocumentType.DeIdCardBack,
-            //RootDocumentType.DePassport,
-        });
+        // configuration.SetAcceptedDocumentTypes(new List<RootDocumentType>
+        // {
+        //     RootDocumentType.DeIdCardFront,
+        //     //RootDocumentType.DeIdCardBack,
+        //     //RootDocumentType.DePassport,
+        // });
 
         // Apply the parameters for fields
         // Use constants from NormalizedFieldNames objects from the corresponding document type

--- a/NET/ReadyToUseUI.iOS/Controller/MainViewController.DataDetectors.cs
+++ b/NET/ReadyToUseUI.iOS/Controller/MainViewController.DataDetectors.cs
@@ -43,7 +43,8 @@ public partial class MainViewController
         {
             var configuration = SBSDKUIGenericDocumentRecognizerConfiguration.DefaultConfiguration;
             configuration.TextConfiguration.CancelButtonTitle = "Done";
-            configuration.BehaviorConfiguration.DocumentType = SBSDKUIDocumentType.IdCardFrontBackDE;
+            // Specify Document types if needed
+            // configuration.BehaviorConfiguration.DocumentType = SBSDKUIDocumentType.IdCardFrontBackDE;
             var controller = SBSDKUIGenericDocumentRecognizerViewController.CreateWithConfigurationAndDelegate(configuration, null);
 
             controller.DidFinishWithDocuments += (_, args) =>


### PR DESCRIPTION
- Droid: Updated the Filter parameter value from passing null to Legacy.None to fix the infinite loading issue
- iOS/Android: Updated the DocumentTypes for GDR, so the User can scan any Document type.